### PR TITLE
updated writePretty to truncate files when writing to them

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### v0.9.1
+   Changed `writePretty` to truncate files when writing to them.
+
 ### v0.9.0
    Changed `writePretty` to use Java interop directly rather than `Files` which has been removed from Flix's stdlib.
 

--- a/flix.toml
+++ b/flix.toml
@@ -1,8 +1,8 @@
 [package]
 name        = "flix-pretty"
 description = "A pretty print library for Flix."
-version     = "0.9.0"
-flix        = "0.54.0"
+version     = "0.9.1"
+flix        = "0.59.0"
 license     = "Apache-2.0"
 authors     = ["Stephen Tetley <stephen.tetley@gmail.com>"]
 

--- a/src/Text/PrettyPrint.flix
+++ b/src/Text/PrettyPrint.flix
@@ -191,9 +191,11 @@ mod Text.PrettyPrint {
             let str = render(width, doc);
             let path1 = unsafe JPath.of(path);
             let cseq: CharSequence = checked_cast(str);
-            let opt = unsafe StandardOpenOption.CREATE;
-            let opt1: JOpenOption = checked_cast(opt);
-            let _ = JFiles.writeString(path1, cseq, ...{opt1});
+            let optC = unsafe StandardOpenOption.CREATE;
+            let optT = unsafe StandardOpenOption.TRUNCATE_EXISTING;
+            let optC1: JOpenOption = checked_cast(optC);
+            let optT1: JOpenOption = checked_cast(optT);
+            let _ = JFiles.writeString(path1, cseq, ...{optC1, optT1});
             true
         })
 

--- a/test/TestPrettyPrint.flix
+++ b/test/TestPrettyPrint.flix
@@ -17,9 +17,9 @@
 
 mod TestPrettyPrint {
 
-
     use Text.PrettyPrint.{<&&>, besideSoftLine, besideSoftSpace, parens, text, 
-        empty, hsep, tupled, optionalTupled, removeEmpties, comma, punctuate}
+        empty, hsep, tupled, optionalTupled, removeEmpties, comma, punctuate,
+        writePretty}
 
     /////////////////////////////////////////////////////////////////////////////
     // empty                                                                   //
@@ -178,4 +178,19 @@ mod TestPrettyPrint {
         let doc1 = optionalTupled(List#{text("A"), empty(), text("B")});
         ToString.toString(doc1) == "(A, B)"
 
+
+    /////////////////////////////////////////////////////////////////////////////
+    // writePretty                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    pub def writePretty01(): Bool \ IO =
+        let testFile = "test/testfile.txt";
+        let res = run {
+            FileWrite.write(str="XXXXXXXXXXXXXX", testFile);
+            let doc1 = text("hello");
+            discard writePretty(testFile, 120, doc1);
+            FileRead.read(testFile)
+        } with FileWrite.runWithIO
+            with FileRead.runWithIO;
+        res == Ok(Ok("hello"))
 }


### PR DESCRIPTION
Hi Stephen,

There's a bug with `writePretty` where it doesn't truncate the file before writing.

This means that if there's a file with the contents
```
XXXXXXX
```
and then I write `hello` to it, the resulting contents are
```
helloXX
```
which is probably not what the user wants.

This PR adds an `OpenOption` to do the right thing, and a test to make sure it's working correctly. The test creates a file in the `test` directory, which may not be fully desirable, but since there's no `.gitignore`, I wasn't quite sure where to put it.

I also updated the `flix.toml` and `HISTORY.md` as appropriate.